### PR TITLE
Use a class variable to store global variables

### DIFF
--- a/lib/i18n/globals.rb
+++ b/lib/i18n/globals.rb
@@ -3,11 +3,11 @@ require 'i18n/globals/version'
 module I18n
   class Config
     def globals
-      @globals ||= {}
+      @@globals ||= {}
     end
 
     def globals=(globals)
-      @globals = globals
+      @@globals = globals
     end
   end
 


### PR DESCRIPTION
This fixes missing global variables for `ActionView::I18nProxy`
instances.
