### PR TITLE
Allow to set different globals per locale

### DIFF
--- a/lib/i18n/globals.rb
+++ b/lib/i18n/globals.rb
@@ -3,21 +3,90 @@ require 'i18n/globals/version'
 
 module I18n
   class Config
-    def globals
-      @@globals ||= {}
+    class CachedGlobals < Hash
+      def []=(key, val)
+        clear_cache
+        annotate_hash(val) if val.is_a?(Hash) # see annotate hash below why whis must be done
+        super(key, val)
+      end
+
+      def for_locale(locale)
+        if key?(locale)
+          globals_cache[locale] ||= merge(fetch(locale)).reject { |_, i| i.is_a?(Hash) }
+        else
+          globals_cache[:default] ||= reject { |_, i| i.is_a?(Hash) }
+        end
+      end
+
+      def clear
+        clear_cache
+        super
+      end
+
+      def merge!(val)
+        clear_cache
+        # see annotate hash below why whis must be done
+        val.select { |_, v| v.is_a?(Hash) }.each { |_, v| annotate_hash(v) }
+        super(val)
+      end
+
+      private
+
+      def globals_cache
+        @globals_cache ||= {}
+      end
+
+      def clear_cache
+        @globals_cache = {}
+      end
+
+      # This is a little bit cumbersome. It might happen that this is done:
+      #
+      #     I18n.config.globals[:en][:welcome] = 'Hello'
+      #
+      # What this does is changing the locale dependent version of `welcome`.
+      # Unfortunately we only override `:[]=` for our globals hash so it
+      # does not detect that the globals have been changed.
+      #
+      # To overcome this we annotate every hash that might passed in with this
+      # method. So when the sub hash is changed like above, the whole cache
+      # is cleared like it should.
+      def annotate_hash(hash)
+        return if hash.instance_variable_defined?(:@cached_global)
+        hash.instance_variable_set(:@cached_global, self)
+
+        def hash.[]=(key, value)
+          super(key, value)
+          @cached_global.send(:clear_cache)
+        end
+
+        def hash.merge!(other_hash)
+          super(other_hash)
+          @cached_global.send(:clear_cache)
+        end
+
+        def hash.clear
+          super
+          @cached_global.send(:clear_cache)
+        end
+      end
     end
 
-    def globals=(globals)
-      @@globals = globals
+    def globals
+      @@globals ||= CachedGlobals.new
+    end
+
+    def globals=(new_globals)
+      globals.clear.merge!(new_globals) # maybe there is something better than `clear` and `merge!`
     end
   end
 
   class << self
     def translate(*args)
       if args.last.is_a?(Hash)
-        args[-1] = config.globals.merge(args.last)
+        args[-1] = config.globals.for_locale(locale).merge(args.last)
       else
-        args << config.globals
+        args << config.globals.for_locale(locale)
       end
       super(*args)
     end

--- a/test/test_i18n_globals.rb
+++ b/test/test_i18n_globals.rb
@@ -6,6 +6,8 @@ class TestI18nGlobals < Minitest::Test
   def setup
     I18n.backend.load_translations 'test/fixtures/translations.yml'
     I18n.config = I18n::Config.new
+    I18n.config.globals = {} # glear globals between runs
+    I18n.locale = :en
   end
 
   def test_that_simple_translations_work
@@ -69,5 +71,101 @@ class TestI18nGlobals < Minitest::Test
     I18n.config = I18n::Config.new
 
     assert_equal I18n.translate('greeting'), 'Hi there, Greg!'
+  end
+
+  def test_that_locale_dependent_variable_overrides_default_one
+    I18n.config.globals = {
+      name: 'Greg',
+      en: { name: 'Debby' }
+    }
+
+    assert_equal 'Hi there, Debby!', I18n.translate('greeting')
+  end
+
+  def test_that_default_variable_is_used_if_no_special_locale_version_is_present
+    I18n.config.globals = {
+      name: 'Greg',
+      fr: { name: 'Debora' }
+    }
+
+    assert_equal 'Hi there, Greg!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_setting_a_new_locale_global
+    I18n.config.globals = {
+      name: 'Greg',
+      en: { name: 'Debby' }
+    }
+
+    assert_equal 'Hi there, Debby!', I18n.translate('greeting')
+
+    I18n.config.globals[:en][:name] = 'Elisa'
+
+    assert_equal 'Hi there, Elisa!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_setting_a_new_locale_hash
+    I18n.config.globals = {
+      name: 'Greg',
+      en: { name: 'Debby' }
+    }
+
+    assert_equal 'Hi there, Debby!', I18n.translate('greeting')
+
+    I18n.config.globals[:en] = {
+      name: 'Elisa'
+    }
+
+    assert_equal 'Hi there, Elisa!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_merging_a_new_locale_hash
+    I18n.config.globals = {
+      name: 'Greg',
+      en: { name: 'Debby' }
+    }
+
+    assert_equal 'Hi there, Debby!', I18n.translate('greeting')
+
+    I18n.config.globals[:en].merge!(name: 'Elisa')
+
+    assert_equal 'Hi there, Elisa!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_clearing_locale_hash
+    I18n.config.globals = {
+      name: 'Greg',
+      en: { name: 'Debby' }
+    }
+
+    assert_equal 'Hi there, Debby!', I18n.translate('greeting')
+
+    I18n.config.globals[:en].clear
+
+    assert_equal 'Hi there, Greg!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_setting_a_new_global
+    I18n.config.globals = {
+      name: 'Greg'
+    }
+
+    assert_equal 'Hi there, Greg!', I18n.translate('greeting')
+
+    I18n.config.globals[:name] = 'Dobby'
+
+    assert_equal 'Hi there, Dobby!', I18n.translate('greeting')
+  end
+
+  def test_that_cache_is_cleared_after_merging_a_new_global
+    I18n.config.globals = {
+      name: 'Greg'
+    }
+
+    assert_equal 'Hi there, Greg!', I18n.translate('greeting')
+
+    I18n.config.globals.merge!(name: 'Dobby')
+
+    assert_equal 'Hi there, Dobby!', I18n.translate('greeting')
   end
 end


### PR DESCRIPTION
This changes the globals that when it has have a `default` key it can
have locale aware globals. For example:

``` ruby
I18n.config.globals = {
  default: {
    salutation: 'Bye bye'
    hello: 'Hello'
  },
  de: {
    salutation: 'Tschüss'
  },
  fr: {
    salutation: 'Salut'
  }
}
```

Depending on the locale, the global variable `salutation` will be
different. A default value is used as a fallback, so that `hello` will
be available in each language, too.

When there is no `default` key it works as before (locale independent).

What this breaks - but only if you have a `default` key in your globals - is setting globals in an before action like stated in the readme:

``` ruby
class EmployeesController < ApplicationController
  before_action :set_i18n_globals

  # ...

  private

  def set_i18n_globals
    I18n.config.globals[:company] = Company.current.name
  end
end
```

It breaks because in the locale aware case the globals are cached on first call (https://github.com/attilahorvath/i18n-globals/pull/5/files#diff-fb7fb950c7f99492dbbb178ff8bd8710R23)

But I am not sure if that is not bad practice anyway - because if you want to have something in your translation which is dependent of the state of the application, you should always pass this directly on your `I18n.t` call (e.g. `I18n.t('welcome', company: Company.current.name)`) IMO.

Nevertheless I'm open to what you say to this @attilahorvath.
