### PR TITLE
Lower gc pressure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
 language: ruby
+rvm:
+  - 2.0
+  - 2.1
+  - 2.2.5
+  - 2.3.1
+  - ruby-head
+matrix:
+  allow_failures:
+    - rvm: ruby-head

--- a/i18n-globals.gemspec
+++ b/i18n-globals.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.0'
+
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'

--- a/lib/i18n/globals.rb
+++ b/lib/i18n/globals.rb
@@ -12,9 +12,9 @@ module I18n
 
       def for_locale(locale)
         if key?(locale)
-          globals_cache[locale] ||= merge(fetch(locale)).reject { |_, i| i.is_a?(Hash) }
+          globals_cache[locale] ||= merge(fetch(locale)).select { |_, i| !i.is_a?(Hash) }
         else
-          globals_cache[:default] ||= reject { |_, i| i.is_a?(Hash) }
+          globals_cache[:default] ||= select { |_, i| !i.is_a?(Hash) }
         end
       end
 

--- a/test/test_i18n_globals.rb
+++ b/test/test_i18n_globals.rb
@@ -209,8 +209,8 @@ class TestI18nGlobals < Minitest::Test
 
     # It looks like I18n.translate by default allocates 2 new hashes
     # per call. So substract it from the count.
-    expected_count = count_after - times * 2
+    created_due_to_globals = count_after - count_before - times * 2
 
-    assert_operator count_before, :==, expected_count
+    assert_equal created_due_to_globals, 0
   end
 end


### PR DESCRIPTION
By using the `missing_interpolation_argument_handler` and not always merging the globals with local interpolation values, it does not create a new hash for each call anymore. Lowers GC pressure noticeable.

This adds some complexity in favour of performance ... what do you say @attilahorvath?

Created on top of #5 and #7, so when they are merged, this is cleaner.
