### PR TITLE
fix ruby warnings by using `select` instead of `reject`

### DIFF
--- a/lib/i18n/globals.rb
+++ b/lib/i18n/globals.rb
@@ -12,9 +12,9 @@ module I18n
 
       def for_locale(locale)
         if key?(locale)
-          globals_cache[locale] ||= merge(fetch(locale)).reject { |_, i| i.is_a?(Hash) }
+          globals_cache[locale] ||= merge(fetch(locale)).select { |_, i| !i.is_a?(Hash) }
         else
-          globals_cache[:default] ||= reject { |_, i| i.is_a?(Hash) }
+          globals_cache[:default] ||= select { |_, i| !i.is_a?(Hash) }
         end
       end
 


### PR DESCRIPTION
Not sure why `reject` gives warnings, `select` not ...

Fixes some warnings on Ruby version >= 2

Edit: See https://travis-ci.org/attilahorvath/i18n-globals/jobs/158737755 for an example of those warnings (it is a build for a different PR but the warning are because of this here).
